### PR TITLE
Fix warning about type cast sizing

### DIFF
--- a/src/opussum/decoder.nim
+++ b/src/opussum/decoder.nim
@@ -103,7 +103,7 @@ proc decode*(decoder: OpusDecoder, encoded: OpusFrame, errorCorrection: bool = f
     encoded.len.opusInt32,
     unsafeAddr result[0],
     cint(maxFrameSize),
-    cast[cint](errorCorrection)
+    cint(errorCorrection)
     )
   checkRC frameSize
   result.setLen frameSize * decoder.channels


### PR DESCRIPTION
Fixes this warning that appears when using latest Nim versions
```
opussum/decoder.nim(106, 5) Warning: target type is larger than source type
```